### PR TITLE
Use patched apk-tools in build process

### DIFF
--- a/build/build_apk_tools.sh
+++ b/build/build_apk_tools.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+APK_TOOLS_DIR="$SCRIPT_DIR/apk-tools"
+
+if [ ! -d "$APK_TOOLS_DIR" ]; then
+  git clone https://github.com/AriannaMethod/AM-alpine-apk-tools "$APK_TOOLS_DIR"
+fi
+
+make -C "$APK_TOOLS_DIR"
+
+# Print path to built apk binary
+echo "$APK_TOOLS_DIR/src/apk"

--- a/build/build_ariannacore.sh
+++ b/build/build_ariannacore.sh
@@ -68,13 +68,17 @@ if [ ! -f acroot/.unpacked ]; then
   touch acroot/.unpacked
 fi
 
-# //: install runtime packages
+# //: build and stage patched apk-tools
+APK_BIN="$("$SCRIPT_DIR/build_apk_tools.sh")"
+install -Dm755 "$APK_BIN" acroot/usr/bin/apk
+
+# //: install runtime packages using the patched apk
 PKGS="bash curl nano nodejs npm"
 if [ "$WITH_PY" -eq 1 ]; then
   PKGS="$PKGS python3 py3-pip py3-virtualenv"
 fi
 # shellcheck disable=SC2086
-apk --root acroot --repositories-file /etc/apk/repositories add --no-cache $PKGS
+"$APK_BIN" --root acroot --repositories-file /etc/apk/repositories add --no-cache $PKGS
 
 # //: include assistant, startup hook, motd and log dir
 install -Dm755 "$ROOT_DIR/assistant.py" acroot/usr/bin/assistant

--- a/tests/test_apk_tools.py
+++ b/tests/test_apk_tools.py
@@ -1,0 +1,8 @@
+import subprocess
+from pathlib import Path
+
+def test_build_custom_apk():
+    script = Path(__file__).resolve().parents[1] / "build" / "build_apk_tools.sh"
+    apk_path = subprocess.check_output([str(script)]).decode().strip()
+    assert Path(apk_path).is_file()
+    subprocess.check_call([apk_path, "--version"])


### PR DESCRIPTION
## Summary
- build patched apk-tools from AM-alpine-apk-tools
- stage custom apk into acroot and use it to install packages
- add regression test ensuring apk binary builds and reports version

## Testing
- `pytest` *(failed: Username for 'https://github.com')*


------
https://chatgpt.com/codex/tasks/task_e_68932e29f6d08329aa35da78496248da