### PR TITLE
Add streaming log summarization with limit option

### DIFF
--- a/tests/test_summarize.py
+++ b/tests/test_summarize.py
@@ -24,3 +24,14 @@ def test_summarize_large_log(tmp_path, monkeypatch):
     result = assistant.summarize("match")
     expected = "\n".join(lines[-5:])
     assert result == expected
+
+
+def test_summarize_respects_limit(tmp_path, monkeypatch):
+    log_dir = tmp_path / "log"
+    log_dir.mkdir()
+    lines = [f"{i} match" for i in range(10)]
+    _write_log(log_dir, "small", lines)
+    monkeypatch.setattr(assistant, "LOG_DIR", log_dir)
+    result = assistant.summarize("match", limit=3)
+    expected = "\n".join(lines[-3:])
+    assert result == expected


### PR DESCRIPTION
## Summary
- stream log files line-by-line and collect matches with a bounded deque
- add `--limit` option to `/summarize` and parse arguments safely
- test that `summarize` honours the `limit` parameter

## Testing
- `python -m flake8 assistant.py tests/test_summarize.py && echo "flake8 passed"`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68932e5b632c832990ce7f894bd95669