### PR TITLE
Add minimal Alpine setup scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ The project ships a single entry script, `./build/build_ariannacore.sh`, which a
 
 Passing `--with-python` expands the userland with the CPython runtime and tooling. The `--clean` flag wipes previous artifacts, and `--test-qemu` executes a minimal boot in QEMU to validate that the emission succeeded.
 
+During the build, a curated subset of Alpine's setup utilities is installed (`setup-alpine`, `setup-hostname`, `setup-interfaces`, `setup-keymap`, `setup-timezone`, `setup-user`, `setup-apkrepos`, `setup-dns`). These scripts provide basic system configuration while keeping the kernel CPU-only and the image lightweight.
+
 ## Checksum verification
 
 For reproducibility the build script verifies downloads against known SHA256 sums using:

--- a/build/build_ariannacore.sh
+++ b/build/build_ariannacore.sh
@@ -66,6 +66,18 @@ if [ ! -f acroot/.unpacked ]; then
   touch acroot/.unpacked
 fi
 
+# //: install minimal alpine configuration scripts
+CONF_SRC="$ROOT_DIR/for-codex-alpine-conf"
+SEDS=(-e "s:@PREFIX@:/usr:g" -e "s:@VERSION@:3.20.0:g" -e "s:@sysconfdir@:/etc/lbu:g")
+install -d acroot/usr/lib acroot/usr/sbin
+sed "${SEDS[@]}" "$CONF_SRC/libalpine.sh.in" > acroot/usr/lib/libalpine.sh
+chmod 644 acroot/usr/lib/libalpine.sh
+CORE_SCRIPTS=(setup-alpine setup-apkrepos setup-hostname setup-interfaces setup-keymap setup-timezone setup-user setup-dns)
+for s in "${CORE_SCRIPTS[@]}"; do
+  sed "${SEDS[@]}" "$CONF_SRC/$s.in" > "acroot/usr/sbin/$s"
+  chmod 755 "acroot/usr/sbin/$s"
+done
+
 # //: build and stage patched apk-tools
 APK_BIN="$("$SCRIPT_DIR/build_apk_tools.sh")"
 install -Dm755 "$APK_BIN" acroot/usr/bin/apk


### PR DESCRIPTION
## Summary
- copy a minimal set of Alpine setup utilities into `acroot` during build
- document the added tools while noting the kernel stays CPU-only and lightweight

## Testing
- `shellcheck --version` *(fails: command not found)*
- `./run-tests.sh` *(fails: subprocess.CalledProcessError: Command '['/workspace/Arianna-Linux-Kernel/build/build_apk_tools.sh']' returned non-zero exit status 2.)*

------
https://chatgpt.com/codex/tasks/task_e_68933be61f908329922ed284cd2c0f48