### PR TITLE
Integrate Alpine config scripts into initramfs

### DIFF
--- a/build/build_ariannacore.sh
+++ b/build/build_ariannacore.sh
@@ -66,6 +66,14 @@ if [ ! -f acroot/.unpacked ]; then
   touch acroot/.unpacked
 fi
 
+# //: build and install Alpine configuration utilities (CPU-only)
+make -C "$ROOT_DIR/for-codex-alpine-conf"
+make -C "$ROOT_DIR/for-codex-alpine-conf" install PREFIX=/usr DESTDIR="$SCRIPT_DIR/acroot"
+rm -f \
+  acroot/usr/sbin/setup-desktop \
+  acroot/usr/sbin/setup-wayland-base \
+  acroot/usr/sbin/setup-xorg-base
+
 # //: build and stage patched apk-tools
 APK_BIN="$("$SCRIPT_DIR/build_apk_tools.sh")"
 install -Dm755 "$APK_BIN" acroot/usr/bin/apk


### PR DESCRIPTION
## Summary
- build and install Alpine configuration utilities into the initramfs staging area
- drop GPU-oriented setup scripts to keep the image CPU-only

## Testing
- `shellcheck build/build_ariannacore.sh`
- `pytest tests/test_apk_tools.py::test_build_custom_apk -vv` *(fails: could not read Username for 'https://github.com')*
- `gzip -dc test.initramfs.gz | cpio -t | grep usr/bin/uniso`
- `gzip -dc test.initramfs.gz | cpio -t | grep -E 'setup-(desktop|wayland-base|xorg-base)' || echo none`

------
https://chatgpt.com/codex/tasks/task_e_689339951b7c83299bf10ef94f9d5b32