### PR TITLE
Add configurable prompt and colors

### DIFF
--- a/docs/letsgo-config-example.md
+++ b/docs/letsgo-config-example.md
@@ -1,0 +1,20 @@
+# LetsGo configuration example
+
+Create `~/.letsgo/config` to customize the LetsGo prompt and colors. Each line
+uses the format `name=value`. Values may include escape sequences like
+`\033` for ANSI colors.
+
+```
+prompt=">> "
+green="\033[32m"
+red="\033[31m"
+cyan="\033[36m"
+reset="\033[0m"
+```
+
+Parameters:
+
+- `prompt` – text displayed for the input prompt.
+- `green`, `red`, `cyan` – ANSI color codes used for status messages, errors
+  and the prompt.
+- `reset` – code to reset terminal colors.


### PR DESCRIPTION
## Summary
- load prompt and color codes from `~/.letsgo/config`
- apply configured colors and prompt in LetsGo console
- document configuration options with example file

## Testing
- `flake8 letsgo.py`
- `./run-tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_6893625b63f8832980d1e33759b03858