### PR TITLE
Refactor command system and add plugin support

### DIFF
--- a/plugins/__init__.py
+++ b/plugins/__init__.py
@@ -1,0 +1,1 @@
+"""Built-in example plugins for LetsGo."""

--- a/plugins/sample.py
+++ b/plugins/sample.py
@@ -1,0 +1,8 @@
+from letsgo import register_command
+
+
+def greet(_: str) -> str:
+    return "Hello from plugin"
+
+
+register_command("/greet", greet)

--- a/tests/test_letsgo.py
+++ b/tests/test_letsgo.py
@@ -53,3 +53,8 @@ def test_current_time_format():
 def test_run_command():
     output = letsgo.run_command("echo hello")
     assert output.strip() == "hello"
+
+
+def test_plugin_loaded():
+    assert "/greet" in letsgo.COMMAND_HANDLERS
+    assert letsgo.COMMAND_HANDLERS["/greet"]("") == "Hello from plugin"


### PR DESCRIPTION
## Summary
- replace hardcoded command list with registry and registration helper
- support auto-loading plugins that register new commands
- update terminal to dispatch commands via registry with better autocomplete
- add sample plugin and tests

## Testing
- `./run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6893647ebe0083299b9750889b4416da