### PR TITLE
feat: add history search and log retention

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,13 +118,13 @@ Other interfaces—serial TTYs, named pipes or custom RPC schemes—remain feasi
 
 ## letsgo.py
 
-The terminal is invoked after login and serves as the primary shell for Arianna Core. Each session creates a fresh log in `/arianna_core/log/`, stamped with UTC time, ensuring chronological reconstruction of interactions.
+The terminal is invoked after login and serves as the primary shell for Arianna Core. Each session creates a fresh log in `/arianna_core/log/`, stamped with UTC time, ensuring chronological reconstruction of interactions. A `max_log_files` option in `~/.letsgo/config` limits how many of these log files are kept on disk.
 
-Command history is persisted to `/arianna_core/log/history`. Existing entries load at startup and are written back on exit. Tab completion, powered by `readline`, suggests built-in verbs like `/status`, `/time`, `/run`, `/summarize`, and `/help`.
+Command history is persisted to `/arianna_core/log/history`. Existing entries load at startup and are written back on exit. Tab completion, powered by `readline`, suggests built-in verbs like `/status`, `/time`, `/run`, `/summarize`, `/search`, and `/help`.
 
 A `/status` command reports CPU core count, raw uptime seconds read from `/proc/uptime`, and the current host IP. This offers an at-a-glance check that the minimal environment is healthy.
 
-The `/summarize` command performs a naive search across all session logs and prints the last five matches, demonstrating how higher-order reasoning can be layered atop simple text filters.
+The `/summarize` command searches across logs with optional regular expressions and prints the last five matches; adding `--history` switches the search to the command history. `/search <pattern>` prints every history line matching the given regex.
 
 For quick information retrieval `/time` prints the current UTC timestamp, while `/run <cmd>` executes a shell command and returns its output. A `/help` command lists the available verbs.
 


### PR DESCRIPTION
## Summary
- limit the number of stored logs via configurable `max_log_files`
- enable regex-based summarization and history searches with new `/search`
- document usage and configuration updates

## Testing
- `flake8 && echo 'flake8 passed'`
- `./run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_689364c14b748329b61c26e97a23f1a8