### PR TITLE
Stream command output asynchronously

### DIFF
--- a/tests/test_letsgo.py
+++ b/tests/test_letsgo.py
@@ -2,6 +2,7 @@ import os
 import re
 import sys
 from pathlib import Path
+import asyncio
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
@@ -51,7 +52,7 @@ def test_current_time_format():
 
 
 def test_run_command():
-    output = letsgo.run_command("echo hello")
+    output = asyncio.run(letsgo.run_command("echo hello"))
     assert output.strip() == "hello"
 
 


### PR DESCRIPTION
## Summary
- stream `/run` command output line-by-line using `asyncio.create_subprocess_shell`
- convert terminal `main` loop to `asyncio.run` for non-blocking input
- adjust tests to await async command execution

## Testing
- `./run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_689367531868832986799e46f558d0ed