### PR TITLE
feat: complete paths for run command

### DIFF
--- a/letsgo.py
+++ b/letsgo.py
@@ -268,7 +268,22 @@ async def main() -> None:
     readline.parse_and_bind("tab: complete")
 
     def completer(text: str, state: int) -> str | None:
-        matches = [cmd for cmd in COMMANDS if cmd.startswith(text)]
+        buffer = readline.get_line_buffer()
+        if buffer.startswith("/run "):
+            path = Path(text)
+            directory = path.parent if path.parent != Path(".") else Path(".")
+            try:
+                entries = os.listdir(directory)
+            except OSError:
+                matches: list[str] = []
+            else:
+                matches = [
+                    str(directory / entry) if directory != Path(".") else entry
+                    for entry in entries
+                    if entry.startswith(path.name)
+                ]
+        else:
+            matches = [cmd for cmd in COMMANDS if cmd.startswith(text)]
         return matches[state] if state < len(matches) else None
 
     readline.set_completer(completer)


### PR DESCRIPTION
## Summary
- support filesystem suggestions when `/run` has an argument by using `os.listdir`

## Testing
- `flake8 letsgo.py` *(fails: subprocess imported but unused; line too long; blank line before nested def)*
- `./run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68936ad44bfc83298f5cacb4f5b2415f