### PR TITLE
feat: use prompt toolkit for interactive input

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+prompt_toolkit


### PR DESCRIPTION
## Summary
- use `prompt_toolkit` for interactive input with history and completion
- add fallback to readline if `prompt_toolkit` is missing
- cover new input behavior with tests and add requirement

## Testing
- `flake8`
- `./run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68936c7fd6008329a6b8d19000d6d55e