### PR TITLE
Add logsearch and tail commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,11 +120,11 @@ Other interfaces—serial TTYs, named pipes or custom RPC schemes—remain feasi
 
 The terminal is invoked after login and serves as the primary shell for Arianna Core. Each session creates a fresh log in `/arianna_core/log/`, stamped with UTC time, ensuring chronological reconstruction of interactions. A `max_log_files` option in `~/.letsgo/config` limits how many of these log files are kept on disk.
 
-Command history is persisted to `/arianna_core/log/history`. Existing entries load at startup and are written back on exit. Tab completion, powered by `readline`, suggests built-in verbs like `/status`, `/time`, `/run`, `/summarize`, `/search`, and `/help`.
+Command history is persisted to `/arianna_core/log/history`. Existing entries load at startup and are written back on exit. Tab completion, powered by `readline`, suggests built-in verbs like `/status`, `/time`, `/run`, `/summarize`, `/logsearch`, `/tail`, `/search`, and `/help`.
 
 A `/status` command reports CPU core count, raw uptime seconds read from `/proc/uptime`, and the current host IP. This offers an at-a-glance check that the minimal environment is healthy.
 
-The `/summarize` command searches across logs with optional regular expressions and prints the last five matches; adding `--history` switches the search to the command history. `/search <pattern>` prints every history line matching the given regex.
+The `/summarize` command searches across logs with optional regular expressions and prints the last five matches; adding `--history` switches the search to the command history. `/logsearch <term> [limit]` performs the same search across all log files without touching history, while `/tail [N]` shows the last `N` lines of the current session log. `/search <pattern>` prints every history line matching the given regex.
 
 For quick information retrieval `/time` prints the current UTC timestamp, while `/run <cmd>` executes a shell command and returns its output. A `/help` command lists the available verbs.
 

--- a/tests/test_summarize.py
+++ b/tests/test_summarize.py
@@ -24,3 +24,22 @@ def test_summarize_large_log(tmp_path, monkeypatch):
     result = letsgo.summarize("match")
     expected = "\n".join(lines[-5:])
     assert result == expected
+
+
+def test_tail_last_lines(tmp_path, monkeypatch):
+    log_file = tmp_path / "session.log"
+    lines = [str(i) for i in range(30)]
+    log_file.write_text("\n".join(lines) + "\n")
+    monkeypatch.setattr(letsgo, "LOG_PATH", log_file)
+    assert letsgo.tail().splitlines() == lines[-20:]
+    assert letsgo.tail(5).splitlines() == lines[-5:]
+
+
+def test_logsearch_across_files(tmp_path, monkeypatch):
+    log_dir = tmp_path / "log"
+    log_dir.mkdir()
+    _write_log(log_dir, "one", ["foo", "bar"])
+    _write_log(log_dir, "two", ["baz foo", "qux foo"])
+    monkeypatch.setattr(letsgo, "LOG_DIR", log_dir)
+    result = letsgo.logsearch("foo", 2)
+    assert result == "baz foo\nqux foo"


### PR DESCRIPTION
## Summary
- add `/tail` command to show recent lines from current log
- add `/logsearch` command for searching across all logs
- document new commands and tests

## Testing
- `pytest >/tmp/unit.log && tail -n 20 /tmp/unit.log`


------
https://chatgpt.com/codex/tasks/task_e_68936ce45fa4832983e5dc02fd46fe8d