### PR TITLE
Add linting configuration and integrate with test runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,21 @@ Then assemble the kernel and userland:
 
 The second script fetches kernel sources, stages `arianna_core_root` built from the Alpine lineage, and emits a flat image. The optional flags expand the userland, clean previous artifacts or run a QEMU smoke test.
 
+## Linting
+
+Run static analysis before pushing changes (install `flake8`, `flake8-pyproject`, and `black` if missing):
+
+```
+./run-tests.sh
+```
+
+This script executes `flake8` and `black --check` followed by the test suite. To run the linters directly:
+
+```
+flake8 .
+black --check .
+```
+
 ## Lineage utilities
 
 The `apk-tools` directory carries a patched `apk` built by `build_apk_tools.sh`, enabling package installs without heavy dependencies.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,7 @@
+[tool.black]
+line-length = 88
+
+[tool.flake8]
+max-line-length = 88
+extend-ignore = ["E203", "W503"]
+

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,3 +1,6 @@
 #!/usr/bin/env bash
 set -e
+
+flake8 .
+black --check .
 pytest "$@"

--- a/tests/test_letsgo.py
+++ b/tests/test_letsgo.py
@@ -11,6 +11,7 @@ import letsgo  # noqa: E402
 
 # Helper to create log files
 
+
 def _write_log(log_dir: Path, name: str, lines: list[str]):
     path = log_dir / f"{name}.log"
     with path.open("w") as fh:
@@ -77,7 +78,9 @@ def test_run_command_mock(monkeypatch):
     async def fake_create_subprocess_shell(cmd, stdout=None, stderr=None):
         return DummyProcess()
 
-    monkeypatch.setattr(asyncio, "create_subprocess_shell", fake_create_subprocess_shell)
+    monkeypatch.setattr(
+        asyncio, "create_subprocess_shell", fake_create_subprocess_shell
+    )
 
     lines: list[str] = []
 


### PR DESCRIPTION
## Summary
- configure Black and Flake8 via a new `pyproject.toml`
- run `flake8` and `black --check` from `run-tests.sh`
- document how to invoke linters locally

## Testing
- `./run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6893709459648329bb0ebb3808b4ae41