### PR TITLE
Show help suggestion for unknown commands

### DIFF
--- a/letsgo.py
+++ b/letsgo.py
@@ -410,8 +410,8 @@ async def main() -> None:
         if handler:
             reply, colored = await handler(user)
         else:
-            reply = f"echo: {user}"
-            colored = reply
+            reply = f"Unknown command: {base}. Try /help for guidance."
+            colored = color(reply, SETTINGS.red)
         if colored is not None:
             print(colored)
         log(f"letsgo:{reply}")


### PR DESCRIPTION
## Summary
- highlight unknown commands in red and point users to `/help`

## Testing
- `flake8 --max-line-length 88`
- `black --check .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6893733a9db88329a499830481a0a850