### PR TITLE
feat: add history command

### DIFF
--- a/letsgo.py
+++ b/letsgo.py
@@ -214,6 +214,15 @@ def history(limit: int = 20) -> str:
     return "\n".join(lines[-limit:])
 
 
+def show_history() -> str:
+    """Return the entire command history."""
+    try:
+        with HISTORY_PATH.open() as fh:
+            return fh.read()
+    except FileNotFoundError:
+        return "no history"
+
+
 def _iter_log_lines() -> Iterable[str]:
     """Yield log lines from all log files in order."""
     for file in sorted(LOG_DIR.glob("*.log")):
@@ -301,8 +310,10 @@ async def handle_clear(_: str) -> Tuple[str, str | None]:
 
 async def handle_history(user: str) -> Tuple[str, str | None]:
     parts = user.split()
-    limit = int(parts[1]) if len(parts) > 1 and parts[1].isdigit() else 20
-    reply = history(limit)
+    if len(parts) > 1 and parts[1].isdigit():
+        reply = history(int(parts[1]))
+    else:
+        reply = show_history()
     return reply, reply
 
 

--- a/tests/test_letsgo.py
+++ b/tests/test_letsgo.py
@@ -109,6 +109,13 @@ def test_history_no_file(tmp_path, monkeypatch):
     assert letsgo.history() == "no history"
 
 
+def test_show_history(tmp_path, monkeypatch):
+    hist = tmp_path / "history"
+    hist.write_text("foo\nbar\n")
+    monkeypatch.setattr(letsgo, "HISTORY_PATH", hist)
+    assert letsgo.show_history().splitlines() == ["foo", "bar"]
+
+
 def test_log_cleanup(tmp_path, monkeypatch):
     log_dir = tmp_path / "log"
     log_dir.mkdir()
@@ -156,3 +163,5 @@ def test_help_lists_command_descriptions():
     output, _ = asyncio.run(letsgo.handle_help("/help"))
     assert "/clear" in output
     assert "clear the terminal screen" in output
+    assert "/history" in output
+    assert "show command history" in output


### PR DESCRIPTION
## Summary
- provide a `show_history` helper to read the entire command history
- expose `/history` in the core command map and help output
- test history display and help listing

## Testing
- `./run-tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_689372de59d88329bf744b7f0b385845