### PR TITLE
Format help output with detailed usage

### DIFF
--- a/letsgo.py
+++ b/letsgo.py
@@ -90,7 +90,7 @@ HISTORY_PATH = LOG_DIR / "history"
 Handler = Callable[[str], Awaitable[Tuple[str, str | None]]]
 COMMANDS: List[str] = []
 COMMAND_HANDLERS: Dict[str, Handler] = {}
-COMMAND_MAP: Dict[str, Tuple[Handler, str]] = {}
+COMMAND_MAP: Dict[str, Tuple[Handler, str, str]] = {}
 
 
 def _ensure_log_dir() -> None:
@@ -179,7 +179,10 @@ async def run_command(
                 await proc.communicate()
                 return color("command timed out", SETTINGS.red)
             try:
-                line = await asyncio.wait_for(proc.stdout.readline(), timeout=remaining)
+                line = await asyncio.wait_for(
+                    proc.stdout.readline(),
+                    timeout=remaining,
+                )
             except asyncio.TimeoutError:
                 proc.kill()
                 await proc.communicate()
@@ -307,8 +310,18 @@ async def handle_history(user: str) -> Tuple[str, str | None]:
 
 
 async def handle_help(_: str) -> Tuple[str, str | None]:
-    lines = [f"{cmd} - {desc}" for cmd, (_, desc) in sorted(COMMAND_MAP.items())]
-    reply = "\n".join(lines)
+    template = """{cmd}
+  {desc}
+  usage: {usage}"""
+    lines = [
+        template.format(
+            cmd=color(cmd, SETTINGS.cyan),
+            desc=desc,
+            usage=usage,
+        )
+        for cmd, (_, desc, usage) in sorted(COMMAND_MAP.items())
+    ]
+    reply = "\n\n".join(lines)
     return reply, reply
 
 
@@ -335,17 +348,25 @@ async def handle_search(user: str) -> Tuple[str, str | None]:
 
 def register_core(commands: List[str], handlers: Dict[str, Handler]) -> None:
     core_commands = {
-        "/status": (handle_status, "show basic system metrics"),
-        "/time": (handle_time, "show current UTC time"),
-        "/run": (handle_run, "run a shell command"),
-        "/summarize": (handle_summarize, "summarize log entries"),
-        "/clear": (handle_clear, "clear the terminal screen"),
-        "/history": (handle_history, "show command history"),
-        "/help": (handle_help, "show this help message"),
-        "/search": (handle_search, "search command history"),
+        "/status": (handle_status, "show basic system metrics", "/status"),
+        "/time": (handle_time, "show current UTC time", "/time"),
+        "/run": (handle_run, "run a shell command", "/run <cmd>"),
+        "/summarize": (
+            handle_summarize,
+            "summarize log entries",
+            "/summarize [--history] [TERM] [LIMIT]",
+        ),
+        "/clear": (handle_clear, "clear the terminal screen", "/clear"),
+        "/history": (handle_history, "show command history", "/history [N]"),
+        "/help": (handle_help, "show this help message", "/help"),
+        "/search": (
+            handle_search,
+            "search command history",
+            "/search <pattern>",
+        ),
     }
     commands.extend(core_commands.keys())
-    handlers.update({cmd: func for cmd, (func, _) in core_commands.items()})
+    handlers.update({cmd: func for cmd, (func, _, _) in core_commands.items()})
     COMMAND_MAP.update(core_commands)
 
 

--- a/tests/test_letsgo.py
+++ b/tests/test_letsgo.py
@@ -156,3 +156,4 @@ def test_help_lists_command_descriptions():
     output, _ = asyncio.run(letsgo.handle_help("/help"))
     assert "/clear" in output
     assert "clear the terminal screen" in output
+    assert "usage: /clear" in output


### PR DESCRIPTION
## Summary
- Show help text with multi-line template including command name, description, and usage
- Store usage strings in the command registry and colorize command names
- Test help output for usage information

## Testing
- `./run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6893731fd7408329a07e742afa518f8f