### PR TITLE
test: centralize log-writing helper

### DIFF
--- a/tests/test_letsgo.py
+++ b/tests/test_letsgo.py
@@ -4,20 +4,11 @@ import sys
 from pathlib import Path
 import asyncio
 
+from tests.utils import _write_log
+
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 import letsgo  # noqa: E402
-
-
-# Helper to create log files
-
-
-def _write_log(log_dir: Path, name: str, lines: list[str]):
-    path = log_dir / f"{name}.log"
-    with path.open("w") as fh:
-        for line in lines:
-            fh.write(line + "\n")
-    return path
 
 
 def test_status_fields(monkeypatch):

--- a/tests/test_summarize.py
+++ b/tests/test_summarize.py
@@ -1,17 +1,11 @@
 import sys
 from pathlib import Path
 
+from tests.utils import _write_log
+
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 import letsgo  # noqa: E402
-
-
-def _write_log(log_dir, name, lines):
-    path = log_dir / f"{name}.log"
-    with path.open("w") as fh:
-        for line in lines:
-            fh.write(line + "\n")
-    return path
 
 
 def test_summarize_large_log(tmp_path, monkeypatch):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,9 @@
+from pathlib import Path
+
+
+def _write_log(log_dir: Path, name: str, lines: list[str]) -> Path:
+    path = log_dir / f"{name}.log"
+    with path.open("w") as fh:
+        for line in lines:
+            fh.write(line + "\n")
+    return path


### PR DESCRIPTION
## Summary
- add `_write_log` helper to `tests/utils.py`
- use shared helper in tests instead of local definitions

## Testing
- `./run-tests.sh` *(fails: letsgo.py:190:80: E501 line too long (88 > 79 characters); letsgo.py:329:80: E501 line too long (81 > 79 characters))*

------
https://chatgpt.com/codex/tasks/task_e_6893751b55a4832984ee61557fac4cea