### PR TITLE
Add theme-aware configuration for LetsGo

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ Other interfaces—serial TTYs, named pipes or custom RPC schemes—remain feasi
 
 ## letsgo.py
 
-The terminal is invoked after login and serves as the primary shell for Arianna Core. Each session creates a fresh log in `/arianna_core/log/`, stamped with UTC time, ensuring chronological reconstruction of interactions. A `max_log_files` option in `~/.letsgo/config` limits how many of these log files are kept on disk.
+The terminal is invoked after login and serves as the primary shell for Arianna Core. Each session creates a fresh log in `/arianna_core/log/`, stamped with UTC time, ensuring chronological reconstruction of interactions. Configuration is read from `~/.letsgo.toml` (or the path pointed to by `LETSGO_CONFIG`) and can adjust the prompt, theme, color usage, and a `max_log_files` option limiting how many logs are kept on disk. An example file lives at `docs/letsgo.toml.example`.
 
 Command history is persisted to `/arianna_core/log/history`. Existing entries load at startup and are written back on exit. Tab completion, powered by `readline`, suggests built-in verbs like `/status`, `/time`, `/run`, `/summarize`, `/search`, and `/help`.
 

--- a/docs/letsgo-config-example.md
+++ b/docs/letsgo-config-example.md
@@ -1,20 +1,26 @@
 # LetsGo configuration example
 
-Create `~/.letsgo/config` to customize the LetsGo prompt and colors. Each line
-uses the format `name=value`. Values may include escape sequences like
-`\033` for ANSI colors.
+Create `~/.letsgo.toml` or set `LETSGO_CONFIG` to the path of a TOML file to
+customize the LetsGo prompt, theme, and colors. Values may include escape
+sequences like `\033` for ANSI colors.
 
-```
-prompt=">> "
-green="\033[32m"
-red="\033[31m"
-cyan="\033[36m"
-reset="\033[0m"
+```toml
+prompt = ">> "
+theme = "dark"
+use_color = true
+max_log_files = 100
+
+[colors]
+green = "\033[32m"
+red = "\033[31m"
+cyan = "\033[36m"
+reset = "\033[0m"
 ```
 
 Parameters:
 
 - `prompt` – text displayed for the input prompt.
-- `green`, `red`, `cyan` – ANSI color codes used for status messages, errors
-  and the prompt.
-- `reset` – code to reset terminal colors.
+- `theme` – color theme (`light` or `dark`).
+- `use_color` – enable or disable colored output.
+- `max_log_files` – number of log files to retain.
+- `colors.*` – optional ANSI color overrides.

--- a/docs/letsgo.toml.example
+++ b/docs/letsgo.toml.example
@@ -1,0 +1,12 @@
+# Example LetsGo configuration
+prompt = ">> "
+theme = "dark"
+use_color = true
+max_log_files = 100
+
+[colors]
+green = "\033[32m"
+red = "\033[31m"
+cyan = "\033[36m"
+reset = "\033[0m"
+

--- a/tests/test_letsgo.py
+++ b/tests/test_letsgo.py
@@ -20,6 +20,27 @@ def _write_log(log_dir: Path, name: str, lines: list[str]):
     return path
 
 
+def test_load_settings_from_env(tmp_path, monkeypatch):
+    cfg = tmp_path / "cfg.toml"
+    cfg.write_text(
+        'prompt = "$ "\n'
+        "use_color = false\n"
+        'theme = "light"\n'
+        "[colors]\n"
+        'red = "\\u001b[91m"\n'
+    )
+    monkeypatch.setenv("LETSGO_CONFIG", str(cfg))
+    import importlib
+
+    importlib.reload(letsgo)
+    assert letsgo.SETTINGS.prompt == "$ "
+    assert letsgo.SETTINGS.theme == "light"
+    assert letsgo.SETTINGS.colors["red"] == "\u001b[91m"
+    assert letsgo.USE_COLOR is False
+    monkeypatch.delenv("LETSGO_CONFIG", raising=False)
+    importlib.reload(letsgo)
+
+
 def test_status_fields(monkeypatch):
     monkeypatch.setattr(letsgo, "_first_ip", lambda: "1.2.3.4")
     result = letsgo.status()


### PR DESCRIPTION
## Summary
- load configuration from `~/.letsgo.toml` or `LETSGO_CONFIG`
- support light and dark themes with optional color overrides
- document configuration and provide example file

## Testing
- `./run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_689375c286008329ba647c4238ae19a6