### PR TITLE
Add token configuration and connection status UI

### DIFF
--- a/arianna_terminal.html
+++ b/arianna_terminal.html
@@ -5,12 +5,17 @@
 <title>Arianna Terminal</title>
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/xterm/css/xterm.css" />
 <style>
-  body { margin: 0; padding: 0; display: flex; height: 100vh; }
+  body { margin: 0; padding: 0; display: flex; flex-direction: column; height: 100vh; }
   #terminal { flex: 1; }
   .frame { border: 1px solid #666; margin: 8px; flex: 1; }
 </style>
 </head>
 <body>
+<div id="controls">
+  <input id="token-input" type="text" placeholder="Token" />
+  <button id="connect-btn">Connect</button>
+  <span id="status"></span>
+</div>
 <div id="terminal" class="frame"></div>
 <script src="https://cdn.jsdelivr.net/npm/xterm/lib/xterm.js"></script>
 <script>
@@ -26,12 +31,45 @@ const term = new Terminal({
 });
 term.open(document.getElementById('terminal'));
 let buffer = '';
-const token = localStorage.getItem('amlkToken') || 'change-me';
-const ws = new WebSocket(`ws://${location.host}/ws?token=${token}`);
-term.write('>> ');
+let ws;
+const statusEl = document.getElementById('status');
+const tokenInput = document.getElementById('token-input');
+tokenInput.value = localStorage.getItem('amlkToken') || '';
+
+function connect() {
+  const token = localStorage.getItem('amlkToken') || 'change-me';
+  if (ws) {
+    ws.close();
+  }
+  ws = new WebSocket(`ws://${location.host}/ws?token=${token}`);
+  ws.onopen = () => {
+    statusEl.textContent = 'connected';
+    term.write('>> ');
+  };
+  ws.onmessage = ev => {
+    term.write('\r\n' + ev.data + '\r\n>> ');
+  };
+  ws.onclose = () => {
+    statusEl.textContent = 'error';
+    term.write('\r\n[connection closed]\r\n');
+  };
+  ws.onerror = () => {
+    statusEl.textContent = 'error';
+  };
+}
+
+document.getElementById('connect-btn').addEventListener('click', () => {
+  localStorage.setItem('amlkToken', tokenInput.value);
+  connect();
+});
+
+connect();
+
 term.onData(data => {
   if (data === '\r') {
-    ws.send(buffer);
+    if (ws && ws.readyState === WebSocket.OPEN) {
+      ws.send(buffer);
+    }
     buffer = '';
   } else if (data === '\u007f') {
     if (buffer.length > 0) {
@@ -43,10 +81,6 @@ term.onData(data => {
     term.write(data);
   }
 });
-ws.onmessage = ev => {
-  term.write('\r\n' + ev.data + '\r\n>> ');
-};
-ws.onclose = () => term.write('\r\n[connection closed]\r\n');
 </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add UI controls to set amlk token and connect
- show connection status in terminal page

## Testing
- `./run-tests.sh` *(fails: ./bridge.py:6:80: E501 line too long (83 > 79 characters))*


------
https://chatgpt.com/codex/tasks/task_e_6893d0423e2c8329976b3eb9410a3912