### PR TITLE
Add file upload support

### DIFF
--- a/arianna_terminal.html
+++ b/arianna_terminal.html
@@ -178,6 +178,27 @@ if (localStorage.getItem('amlkToken')) {
 } else {
   tokenDialog.showModal();
 }
+
+document.addEventListener('dragover', ev => ev.preventDefault());
+document.addEventListener('drop', async ev => {
+  ev.preventDefault();
+  const file = ev.dataTransfer.files[0];
+  if (!file || !(window.Telegram && window.Telegram.WebApp)) return;
+  try {
+    const buffer = await file.arrayBuffer();
+    const saved = await window.Telegram.WebApp.saveFile({
+      data: buffer,
+      file_name: file.name,
+      mime_type: file.type,
+    });
+    const opened = await window.Telegram.WebApp.openFile({ path: saved.path });
+    const form = new FormData();
+    form.append('file', new File([opened], file.name, { type: file.type }));
+    await fetch('/upload', { method: 'POST', body: form });
+  } catch (err) {
+    console.error('upload failed', err);
+  }
+});
 </script>
 </body>
 </html>

--- a/letsgo.py
+++ b/letsgo.py
@@ -24,6 +24,7 @@ from typing import (
 )
 from dataclasses import dataclass
 import re
+import shutil
 
 _NO_COLOR_FLAG = "--no-color"
 USE_COLOR = (
@@ -96,6 +97,7 @@ HISTORY_PATH = LOG_DIR / "history"
 PY_TIMEOUT = 5
 
 ERROR_LOG_PATH = LOG_DIR / "errors.log"
+UPLOAD_DIR = Path("/arianna_core/upload")
 
 Handler = Callable[[str], Awaitable[Tuple[str, str | None]]]
 
@@ -409,6 +411,23 @@ async def handle_color(user: str) -> Tuple[str, str | None]:
     return reply, color(reply, SETTINGS.green)
 
 
+async def handle_upload(user: str) -> Tuple[str, str | None]:
+    parts = user.split(maxsplit=1)
+    if len(parts) != 2:
+        reply = "Usage: /upload <name>"
+        return reply, reply
+    name = parts[1]
+    src = UPLOAD_DIR / name
+    dest = Path(name)
+    try:
+        shutil.copy(src, dest)
+    except FileNotFoundError:
+        reply = f"File not found: {name}"
+        return reply, color(reply, SETTINGS.red)
+    reply = f"file {name} copied"
+    return reply, reply
+
+
 CORE_COMMANDS: Dict[str, Tuple[Handler, str]] = {
     "/status": (handle_status, "show basic system metrics"),
     "/time": (handle_time, "show current UTC time"),
@@ -421,6 +440,7 @@ CORE_COMMANDS: Dict[str, Tuple[Handler, str]] = {
     "/search": (handle_search, "search command history"),
     "/ping": (handle_ping, "reply with pong"),
     "/color": (handle_color, "toggle colored output"),
+    "/upload": (handle_upload, "copy uploaded file to current directory"),
 }
 
 COMMAND_HANDLERS: Dict[str, Handler] = {

--- a/tests/test_letsgo.py
+++ b/tests/test_letsgo.py
@@ -184,3 +184,27 @@ def test_handle_py_timeout(monkeypatch):
         assert colored.startswith("\033[31m")
     else:
         assert colored is not None
+
+
+def test_handle_upload_copies_file(tmp_path, monkeypatch):
+    upload_dir = tmp_path / "upload"
+    upload_dir.mkdir()
+    src = upload_dir / "data.txt"
+    src.write_text("hello")
+    monkeypatch.setattr(letsgo, "UPLOAD_DIR", upload_dir)
+    monkeypatch.chdir(tmp_path)
+    output, _ = asyncio.run(letsgo.handle_upload("/upload data.txt"))
+    assert (tmp_path / "data.txt").read_text() == "hello"
+    assert "copied" in output
+
+
+def test_handle_upload_missing_file(tmp_path, monkeypatch):
+    upload_dir = tmp_path / "upload"
+    upload_dir.mkdir()
+    monkeypatch.setattr(letsgo, "UPLOAD_DIR", upload_dir)
+    output, colored = asyncio.run(letsgo.handle_upload("/upload nope.txt"))
+    assert "not found" in output
+    if letsgo.USE_COLOR:
+        assert colored.startswith("\033[31m")
+    else:
+        assert colored is not None


### PR DESCRIPTION
## Summary
- add drag-and-drop upload in terminal using Telegram WebApp files API
- expose `/upload` HTTP/WS endpoints in bridge to store files on the robot
- provide `/upload` command to fetch uploaded files and accompanying tests

## Testing
- `./run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6893e7d22b108329a3e26d686d272c48