### PR TITLE
feat: add web editor and file APIs

### DIFF
--- a/arianna_terminal.html
+++ b/arianna_terminal.html
@@ -4,6 +4,7 @@
 <meta charset="UTF-8" />
 <title>Arianna Terminal</title>
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/xterm/css/xterm.css" />
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/codemirror@5.65.13/lib/codemirror.css" />
 <style>
   body { margin: 0; padding: 0; display: flex; flex-direction: column; height: 100vh; }
   .frame { border: 1px solid #666; margin: 8px; flex: 1; }
@@ -28,6 +29,9 @@
   .close-tab { position: absolute; right: 4px; top: 2px; cursor: pointer; }
   #terminal-container { flex: 1; display: flex; }
   .hidden { display: none; }
+  .editor-container { display: flex; flex-direction: column; height: 100%; }
+  .editor-container .CodeMirror { flex: 1; }
+  .editor-controls { margin-bottom: 4px; }
 </style>
 </head>
 <body>
@@ -43,6 +47,7 @@
 </dialog>
 <div id="terminal-container"></div>
 <script src="https://cdn.jsdelivr.net/npm/xterm/lib/xterm.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/codemirror@5.65.13/lib/codemirror.js"></script>
 <script>
 if (window.Telegram && window.Telegram.WebApp) {
   window.Telegram.WebApp.ready();
@@ -71,7 +76,12 @@ function connect(sid, term) {
     term.write('>> ');
   };
   ws.onmessage = ev => {
-    term.write('\r\n' + ev.data + '\r\n>> ');
+    if (ev.data.startsWith('__EDIT__ ')) {
+      openEditor(ev.data.slice(9));
+      term.write('\r\n>> ');
+    } else {
+      term.write('\r\n' + ev.data + '\r\n>> ');
+    }
   };
   ws.onclose = () => {
     setStatus('close');
@@ -161,6 +171,66 @@ function createSession(sid) {
     }
   });
   return sid;
+}
+
+async function openEditor(path) {
+  const token = localStorage.getItem('amlkToken');
+  if (!token) {
+    tokenDialog.showModal();
+    return;
+  }
+  const res = await fetch('/upload', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: 'Basic ' + btoa('web:' + token),
+    },
+    body: JSON.stringify({ path }),
+  });
+  if (!res.ok) {
+    alert('failed to load');
+    return;
+  }
+  const data = await res.json();
+  const sid = 'edit-' + (crypto.randomUUID ? crypto.randomUUID() : Date.now());
+  const el = document.createElement('div');
+  el.className = 'frame hidden editor-container';
+  const controls = document.createElement('div');
+  controls.className = 'editor-controls';
+  const saveBtn = document.createElement('button');
+  saveBtn.textContent = 'save';
+  controls.appendChild(saveBtn);
+  el.appendChild(controls);
+  const ta = document.createElement('textarea');
+  el.appendChild(ta);
+  container.appendChild(el);
+  const editor = CodeMirror.fromTextArea(ta, { lineNumbers: true });
+  editor.setValue(data.content);
+  saveBtn.addEventListener('click', async () => {
+    await fetch('/save', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: 'Basic ' + btoa('web:' + token),
+      },
+      body: JSON.stringify({ path, content: editor.getValue() }),
+    });
+  });
+  const tab = document.createElement('div');
+  tab.className = 'tab';
+  tab.textContent = path.split('/').pop();
+  const closeBtn = document.createElement('span');
+  closeBtn.textContent = '×';
+  closeBtn.className = 'close-tab';
+  closeBtn.addEventListener('click', ev => {
+    ev.stopPropagation();
+    removeSession(sid);
+  });
+  tab.appendChild(closeBtn);
+  tab.addEventListener('click', () => setActive(sid));
+  tabBar.appendChild(tab);
+  sessions[sid] = { tab, el, editor };
+  setActive(sid);
 }
 document.getElementById('new-tab').addEventListener('click', () => {
   setActive(createSession());

--- a/letsgo.py
+++ b/letsgo.py
@@ -409,6 +409,14 @@ async def handle_color(user: str) -> Tuple[str, str | None]:
     return reply, color(reply, SETTINGS.green)
 
 
+async def handle_edit(user: str) -> Tuple[str, str | None]:
+    path = user.partition(" ")[2].strip()
+    if not path:
+        reply = "Usage: edit <path>"
+        return reply, reply
+    return f"__EDIT__ {path}", None
+
+
 CORE_COMMANDS: Dict[str, Tuple[Handler, str]] = {
     "/status": (handle_status, "show basic system metrics"),
     "/time": (handle_time, "show current UTC time"),
@@ -428,6 +436,10 @@ COMMAND_HANDLERS: Dict[str, Handler] = {
 }
 COMMANDS: List[str] = list(COMMAND_HANDLERS.keys())
 COMMAND_MAP: Dict[str, Tuple[Handler, str]] = dict(CORE_COMMANDS)
+
+COMMAND_HANDLERS["edit"] = handle_edit
+COMMANDS.append("edit")
+COMMAND_MAP["edit"] = (handle_edit, "request file edit")
 
 
 def register_core(commands: List[str], handlers: Dict[str, Handler]) -> None:

--- a/tests/test_letsgo.py
+++ b/tests/test_letsgo.py
@@ -184,3 +184,9 @@ def test_handle_py_timeout(monkeypatch):
         assert colored.startswith("\033[31m")
     else:
         assert colored is not None
+
+
+def test_handle_edit_returns_token():
+    output, colored = asyncio.run(letsgo.handle_edit("edit foo.txt"))
+    assert output == "__EDIT__ foo.txt"
+    assert colored is None


### PR DESCRIPTION
## Summary
- integrate CodeMirror editor into web terminal
- add limited filesystem upload/save APIs
- support `edit <file>` command to trigger editor

## Testing
- `./run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6893e805e54883299368c5583085a764