### PR TITLE
feat: improve CLI usability

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,15 +158,15 @@ Other interfaces—serial TTYs, named pipes or custom RPC schemes—remain feasi
 
 letsgo.py
 
-The terminal is invoked after login and serves as the primary shell for Arianna Core. Each session creates a fresh log in /arianna_core/log/, stamped with UTC time, ensuring chronological reconstruction of interactions. A max_log_files option in ~/.letsgo/config limits how many of these log files are kept on disk.
+The terminal is invoked after login and serves as the primary shell for Arianna Core. Each session creates a fresh log in `~/.letsgo/log/`, stamped with UTC time, ensuring chronological reconstruction of interactions. A `max_log_files` option in `~/.letsgo/config` limits how many of these log files are kept on disk.
 
-Command history is persisted to /arianna_core/log/history. Existing entries load at startup and are written back on exit. Tab completion, powered by readline, suggests built-in verbs like /status, /time, /run, /summarize, /search, /color, and /help.
+Command history is persisted to `~/.letsgo/history`. Existing entries load at startup and are written back on exit. Tab completion, powered by readline, suggests built-in verbs like `/status`, `/time`, `/run`, `/summarize`, `/search`, `/color`, and `/help`. Arrow-key history search and `Ctrl-R` reverse search are also available.
 
 A /status command reports CPU core count, raw uptime seconds read from /proc/uptime, and the current host IP. This offers an at-a-glance check that the minimal environment is healthy.
 
 The /summarize command searches across logs with optional regular expressions and prints the last five matches; adding --history switches the search to the command history. /search <pattern> prints every history line matching the given regex.
 
-For quick information retrieval /time prints the current UTC timestamp, while /run <cmd> executes a shell command and returns its output. A /help command lists the available verbs. Use /color on|off to toggle colored output.
+For quick information retrieval `/time` prints the current UTC timestamp, while `/run <cmd>` executes a shell command and returns its output. The `/help [cmd]` command lists the available verbs or shows detailed help for a specific command. Use `/color on|off` to toggle colored output.
 
 ### Command Overview
 

--- a/bridge.py
+++ b/bridge.py
@@ -171,7 +171,8 @@ async def handle_telegram(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
     except Exception as exc:  # noqa: BLE001 - send error to user
         await update.message.reply_text(f"Error: {exc}")
         return
-    if cmd in MAIN_COMMANDS:
+    base = cmd.split()[0]
+    if base in MAIN_COMMANDS:
         await update.message.reply_text(output, reply_markup=INLINE_KEYBOARD)
     else:
         await update.message.reply_text(output)

--- a/tests/test_letsgo.py
+++ b/tests/test_letsgo.py
@@ -161,6 +161,20 @@ def test_help_lists_command_descriptions():
     assert "show command history" in output
 
 
+def test_help_specific_command():
+    commands = []
+    handlers = {}
+    letsgo.COMMAND_MAP.clear()
+    letsgo.register_core(commands, handlers)
+    output, _ = asyncio.run(letsgo.handle_help("/help /time"))
+    assert "Usage: /time" in output
+
+
+def test_help_unknown_command():
+    output, _ = asyncio.run(letsgo.handle_help("/help /missing"))
+    assert "No help available for /missing" in output
+
+
 def test_handle_py_executes_code():
     output, colored = asyncio.run(letsgo.handle_py("/py print('hi')"))
     assert output == "hi"


### PR DESCRIPTION
## Summary
- add history-aware autocompletion and persistent config paths
- support `help <cmd>` with detailed hints
- wire help output through Telegram bridge

## Testing
- `./run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6893e814d7e48329a6c0cb0f9790d576