### PR TITLE
Add WebApp button to Telegram bridge

### DIFF
--- a/tests/test_webapp.py
+++ b/tests/test_webapp.py
@@ -1,0 +1,10 @@
+from fastapi.testclient import TestClient
+
+from bridge import app
+
+
+def test_webapp_served() -> None:
+    client = TestClient(app)
+    resp = client.get("/webapp")
+    assert resp.status_code == 200
+    assert "Arianna Terminal" in resp.text


### PR DESCRIPTION
## Summary
- serve `arianna_terminal.html` from new `/webapp` FastAPI route
- expose WebApp link via inline keyboard button in Telegram responses
- cover `/webapp` endpoint with tests

## Testing
- `./run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6893e83eba4c8329b86e2f780d3f8b11