### PR TITLE
Expose WebApp session and file viewing commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,18 +160,20 @@ letsgo.py
 
 The terminal is invoked after login and serves as the primary shell for Arianna Core. Each session creates a fresh log in /arianna_core/log/, stamped with UTC time, ensuring chronological reconstruction of interactions. A max_log_files option in ~/.letsgo/config limits how many of these log files are kept on disk.
 
-Command history is persisted to /arianna_core/log/history. Existing entries load at startup and are written back on exit. Tab completion, powered by readline, suggests built-in verbs like /status, /time, /run, /summarize, /search, /color, and /help.
+Command history is persisted to /arianna_core/log/history. Existing entries load at startup and are written back on exit. Tab completion, powered by readline, suggests built-in verbs like /status, /time, /run, /summarize, /search, /color, /sessions, /open, and /help.
 
 A /status command reports CPU core count, raw uptime seconds read from /proc/uptime, and the current host IP. This offers an at-a-glance check that the minimal environment is healthy.
 
 The /summarize command searches across logs with optional regular expressions and prints the last five matches; adding --history switches the search to the command history. /search <pattern> prints every history line matching the given regex.
 
-For quick information retrieval /time prints the current UTC timestamp, while /run <cmd> executes a shell command and returns its output. A /help command lists the available verbs. Use /color on|off to toggle colored output.
+For quick information retrieval /time prints the current UTC timestamp, while /run <cmd> executes a shell command and returns its output. A /help command lists the available verbs. Use /color on|off to toggle colored output. The /sessions and /open commands interact with the accompanying WebApp via WebSockets to manage tabs and display uploaded files.
 
 ### Command Overview
 
 - `/status` – show CPU core count, uptime, and host IP.
 - `/time` – display the current UTC time.
+- `/open <file>` – view an uploaded file through the WebApp.
+- `/sessions [id]` – list or switch terminal sessions in the WebApp.
 - `/help` – list available commands.
 
 By default any unrecognised input is echoed back, but the structure is prepared for more advanced NLP pipelines. Hooks can intercept the text and dispatch it to remote models, feeding results back through the same interface.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 fastapi
 uvicorn[standard]
 python-telegram-bot
+websockets


### PR DESCRIPTION
## Summary
- add WebSocket helper and handlers for `/sessions` and `/open` in `letsgo.py`
- register new commands and document WebApp integration
- cover session/file helpers with tests and add websockets dependency

## Testing
- `bash run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6893e86b6fe083299bff2a19de026005