### PR TITLE
Add python-multipart dependency for uploads

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 fastapi
 uvicorn[standard]
 python-telegram-bot
+python-multipart


### PR DESCRIPTION
## Summary
- ensure FastAPI upload endpoint works by including python-multipart dependency

## Testing
- `flake8 .`
- `black --check .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6893eddd11ec8329baa3f95d1be34e0b