### PR TITLE
Add python-multipart dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 fastapi
 uvicorn[standard]
 python-telegram-bot
+python-multipart


### PR DESCRIPTION
## Summary
- include python-multipart to support FastAPI file uploads

## Testing
- `./run-tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_6893eddd11ec8329baa3f95d1be34e0b