### PR TITLE
Handle whitespace in Telegram token

### DIFF
--- a/bridge.py
+++ b/bridge.py
@@ -261,7 +261,7 @@ async def handle_callback(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
 
 
 async def start_bot() -> None:
-    token = os.getenv("TELEGRAM_TOKEN")
+    token = os.getenv("TELEGRAM_TOKEN", "").strip()
     if not token:
         return
     application = ApplicationBuilder().token(token).build()


### PR DESCRIPTION
## Summary
- strip whitespace from TELEGRAM_TOKEN before building Application

## Testing
- `./run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6893f298590c8329bf070820eb83fbe5