### PR TITLE
fix: strip Telegram token

### DIFF
--- a/bridge.py
+++ b/bridge.py
@@ -261,7 +261,7 @@ async def handle_callback(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
 
 
 async def start_bot() -> None:
-    token = os.getenv("TELEGRAM_TOKEN")
+    token = os.getenv("TELEGRAM_TOKEN", "").strip()
     if not token:
         return
     application = ApplicationBuilder().token(token).build()


### PR DESCRIPTION
## Summary
- prevent Telegram token from including newline characters by stripping env var

## Testing
- `./run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6893f298590c8329bf070820eb83fbe5