### PR TITLE
Persist settings and enhance help handling

### DIFF
--- a/bridge.py
+++ b/bridge.py
@@ -224,6 +224,11 @@ async def start(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
 
 
 async def help_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    cmd = "/help"
+    if context.args:
+        cmd += " " + " ".join(context.args)
+    if update.message:
+        update.message.text = cmd
     await handle_telegram(update, context)
 
 

--- a/tests/test_letsgo.py
+++ b/tests/test_letsgo.py
@@ -222,3 +222,12 @@ def test_handle_upload_missing_file(tmp_path, monkeypatch):
         assert colored.startswith("\033[31m")
     else:
         assert colored is not None
+
+
+def test_color_setting_persisted(tmp_path, monkeypatch):
+    config = tmp_path / "config"
+    monkeypatch.setattr(letsgo, "CONFIG_PATH", config)
+    monkeypatch.setattr(letsgo, "SETTINGS", letsgo.Settings())
+    monkeypatch.setattr(letsgo, "USE_COLOR", True)
+    asyncio.run(letsgo.handle_color("/color off"))
+    assert "use_color=False" in config.read_text()


### PR DESCRIPTION
## Summary
- persist LetsGo settings in `~/.letsgo` and update them on color changes
- forward `/help` arguments from the Telegram bridge for detailed help messages
- test that toggling color persists in the saved config

## Testing
- `./run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6893f3332a988329b9ec661b855911d3