### PR TITLE
Integrate Telegram WebApp with tabbed terminals

### DIFF
--- a/arianna_terminal.html
+++ b/arianna_terminal.html
@@ -4,6 +4,7 @@
 <meta charset="UTF-8" />
 <title>Arianna Terminal</title>
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/xterm/css/xterm.css" />
+<script src="https://telegram.org/js/telegram-web-app.js"></script>
 <style>
   body { margin: 0; padding: 0; display: flex; flex-direction: column; height: 100vh; }
   .frame { border: 1px solid #666; margin: 8px; flex: 1; }
@@ -47,8 +48,10 @@
 <script src="https://cdn.jsdelivr.net/npm/three@0.164.0/build/three.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/three@0.164.0/examples/js/controls/OrbitControls.js"></script>
 <script>
-if (window.Telegram && window.Telegram.WebApp) {
-  window.Telegram.WebApp.ready();
+const tg = window.Telegram?.WebApp;
+if (tg) {
+  tg.ready();
+  tg.expand();
 }
 const statusEl = document.getElementById('status');
 const tokenDialog = document.getElementById('token-dialog');
@@ -166,7 +169,10 @@ function setActive(sid) {
 function removeSession(sid) {
   const session = sessions[sid];
   if (!session) return;
-  session.ws && session.ws.close();
+  if (session.ws && session.ws.readyState === WebSocket.OPEN) {
+    session.ws.send('__close__');
+    session.ws.close();
+  }
   session.tab.remove();
   session.el.remove();
   delete sessions[sid];

--- a/bridge.py
+++ b/bridge.py
@@ -156,6 +156,8 @@ async def websocket_endpoint(websocket: WebSocket) -> None:
     try:
         while True:
             cmd = await websocket.receive_text()
+            if cmd == "__close__":
+                break
             output = await proc.run(cmd)
             await websocket.send_text(output)
     except WebSocketDisconnect:


### PR DESCRIPTION
## Summary
- Load Telegram WebApp API and expand the interface for Telegram environments
- Close terminal sessions gracefully via `__close__` messages and handle them on the server

## Testing
- `./run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6893f38001488329a4253022369fca91