### PR TITLE
Lowercase bot command descriptions

### DIFF
--- a/bridge.py
+++ b/bridge.py
@@ -295,7 +295,9 @@ async def start_bot() -> None:
     if not token:
         return
     application = ApplicationBuilder().token(token).build()
-    commands = [BotCommand(cmd[1:], desc) for cmd, (_, desc) in CORE_COMMANDS.items()]
+    commands = [
+        BotCommand(cmd[1:], desc.lower()) for cmd, (_, desc) in CORE_COMMANDS.items()
+    ]
     await application.bot.set_my_commands(commands)
     application.add_handler(CommandHandler("start", start))
     application.add_handler(CommandHandler("help", help_command))


### PR DESCRIPTION
## Summary
- ensure Telegram command descriptions are lowercase when registering bot commands

## Testing
- `./run-tests.sh`
- `TELEGRAM_TOKEN=dummy python bridge.py` *(fails: httpx.ProxyError: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68940736addc8329b8b56874488dc48c