### PR TITLE
Reset Telegram webhook before polling

### DIFF
--- a/bridge.py
+++ b/bridge.py
@@ -295,6 +295,8 @@ async def start_bot() -> None:
     if not token:
         return
     application = ApplicationBuilder().token(token).build()
+    # Ensure no pending webhook or polling sessions remain
+    await application.bot.delete_webhook(drop_pending_updates=True)
     commands = [BotCommand(cmd[1:], desc) for cmd, (_, desc) in CORE_COMMANDS.items()]
     await application.bot.set_my_commands(commands)
     application.add_handler(CommandHandler("start", start))


### PR DESCRIPTION
## Summary
- Clear existing Telegram webhooks before starting polling to avoid conflicts

## Testing
- `./run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6894037cb2408329bb4dcd71847ee1cc