### PR TITLE
Ensure lowercase Telegram command descriptions

### DIFF
--- a/bridge.py
+++ b/bridge.py
@@ -335,6 +335,7 @@ async def start_bot() -> None:
     if not token:
         return
     application = ApplicationBuilder().token(token).build()
+    # Ensure command descriptions are lowercase for proper Telegram menu display
     commands = [
         BotCommand(cmd[1:], desc.lower()) for cmd, (_, desc) in CORE_COMMANDS.items()
     ]

--- a/tests/test_letsgo.py
+++ b/tests/test_letsgo.py
@@ -207,3 +207,8 @@ def test_color_setting_persisted(tmp_path, monkeypatch):
     monkeypatch.setattr(letsgo, "USE_COLOR", True)
     asyncio.run(letsgo.handle_color("/color off"))
     assert "use_color=False" in config.read_text()
+
+
+def test_core_commands_descriptions_lowercase():
+    for _, (_, desc) in letsgo.CORE_COMMANDS.items():
+        assert desc[0].islower()


### PR DESCRIPTION
## Summary
- Document that Telegram command descriptions are forced to lowercase when registering commands
- Verify `CORE_COMMANDS` descriptions start with lowercase letters

## Testing
- `./run-tests.sh`
- `python bridge.py >/tmp/bot.log 2>&1 & sleep 2; pkill -f 'bridge.py'; tail -n 20 /tmp/bot.log`


------
https://chatgpt.com/codex/tasks/task_e_68941506ff34832983f8c252065c4558