### PR TITLE
feat: improve terminal UI

### DIFF
--- a/arianna_terminal.html
+++ b/arianna_terminal.html
@@ -3,13 +3,52 @@
 <head>
 <meta charset="UTF-8" />
 <title>Arianna Terminal</title>
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link href="https://fonts.googleapis.com/css2?family=Roboto&display=swap" rel="stylesheet" />
+<link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet" />
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/xterm/css/xterm.css" />
 <script src="https://telegram.org/js/telegram-web-app.js"></script>
 <style>
-  body { margin: 0; padding: 0; display: flex; flex-direction: column; height: 100vh; }
-  .frame { border: 1px solid #666; margin: 8px; flex: 1; }
-  #controls { display: flex; align-items: center; gap: 8px; margin: 8px; }
-  #status { font-family: sans-serif; }
+  :root {
+    --bg-color: #ffffff;
+    --fg-color: #000000;
+    --accent-color: #666;
+    --tab-active-bg: #ddd;
+  }
+  [data-theme="dark"] {
+    --bg-color: #1e1e1e;
+    --fg-color: #d4d4d4;
+    --accent-color: #999;
+    --tab-active-bg: #333;
+  }
+  body {
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    height: 100vh;
+    background: var(--bg-color);
+    color: var(--fg-color);
+    font-family: 'Roboto', sans-serif;
+  }
+  .frame {
+    border: 1px solid var(--accent-color);
+    margin: 8px;
+    flex: 1;
+  }
+  #controls {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin: 8px;
+  }
+  #status {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    font-family: inherit;
+  }
   #status::before {
     content: '';
     display: inline-block;
@@ -17,24 +56,47 @@
     height: 10px;
     border-radius: 50%;
     margin-right: 4px;
-    background: #666;
+    background: var(--accent-color);
     vertical-align: middle;
   }
   #status.open::before { background: #0a0; }
   #status.close::before { background: #a00; }
   #status.error::before { background: #e69500; }
-  #tab-bar { display: flex; gap: 4px; margin: 0 8px; }
+  #status.loading::before {
+    border: 2px solid var(--accent-color);
+    border-top-color: var(--fg-color);
+    background: transparent;
+    animation: spin 1s linear infinite;
+  }
+  @keyframes spin {
+    from { transform: rotate(0deg); }
+    to { transform: rotate(360deg); }
+  }
+  #tab-bar { display: flex; gap: 4px; margin: 0 8px; flex-wrap: nowrap; }
   .tab { position: relative; padding: 4px 16px 4px 8px; cursor: pointer; }
-  .tab.active { background: #ddd; }
+  .tab.active { background: var(--tab-active-bg); }
   .close-tab { position: absolute; right: 4px; top: 2px; cursor: pointer; }
   #terminal-container { flex: 1; display: flex; }
   .hidden { display: none; }
+  @media (max-width: 600px) {
+    #controls {
+      flex-direction: column;
+      align-items: stretch;
+    }
+    #tab-bar {
+      flex-wrap: wrap;
+    }
+    .frame {
+      margin: 4px;
+    }
+  }
 </style>
 </head>
 <body>
 <div id="controls">
   <span id="status" class="close">close</span>
-  <button id="new-tab">new</button>
+  <button id="new-tab"><span class="material-icons">add</span></button>
+  <button id="theme-toggle"><span class="material-icons" id="theme-icon">dark_mode</span></button>
 </div>
 <div id="tab-bar"></div>
 <dialog id="token-dialog">
@@ -58,9 +120,29 @@ const tokenDialog = document.getElementById('token-dialog');
 const tokenInput = document.getElementById('token-input');
 const tabBar = document.getElementById('tab-bar');
 const container = document.getElementById('terminal-container');
+const themeToggle = document.getElementById('theme-toggle');
+const themeIcon = document.getElementById('theme-icon');
 const sessions = {};
 let activeSid = null;
 let tabCount = 0;
+
+function applyTheme(theme) {
+  document.body.dataset.theme = theme;
+  const isDark = theme === 'dark';
+  themeIcon.textContent = isDark ? 'light_mode' : 'dark_mode';
+  for (const sid in sessions) {
+    sessions[sid].term.setOption('theme', isDark ? { background: '#1e1e1e', foreground: '#d4d4d4' } : { background: '#ffffff', foreground: '#000000' });
+  }
+  localStorage.setItem('amlkTheme', theme);
+}
+
+themeToggle.addEventListener('click', () => {
+  const next = document.body.dataset.theme === 'dark' ? 'light' : 'dark';
+  applyTheme(next);
+});
+
+const storedTheme = localStorage.getItem('amlkTheme') || (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
+applyTheme(storedTheme);
 
 const threeCanvas = document.getElementById('three-canvas');
 const renderer = new THREE.WebGLRenderer({ canvas: threeCanvas });
@@ -121,40 +203,43 @@ function setStatus(state) {
   statusEl.textContent = state;
   statusEl.className = state;
 }
-function connect(sid, term) {
-  const token = localStorage.getItem('amlkToken');
-  if (!token) {
-    tokenDialog.showModal();
-    return null;
-  }
-  const ws = new WebSocket(`ws://${location.host}/ws?token=${token}&sid=${sid}`);
-  ws.onopen = () => {
-    setStatus('open');
-    term.write('>> ');
-  };
-  ws.onmessage = ev => {
-    const lines = ev.data.split('\n');
-    let out = '';
-    for (const line of lines) {
-      if (line.startsWith('__PLOT__')) {
-        handlePlot(line.slice(8));
-      } else if (line.startsWith('__MODEL__')) {
-        handleModel(line.slice(9));
-      } else if (line) {
-        out += '\r\n' + line;
-      }
+  function connect(sid, term) {
+    const token = localStorage.getItem('amlkToken');
+    if (!token) {
+      tokenDialog.showModal();
+      return null;
     }
-    term.write(out + '\r\n>> ');
-  };
-  ws.onclose = () => {
-    setStatus('close');
-    term.write('\r\n[connection closed]\r\n');
-  };
-  ws.onerror = () => {
-    setStatus('error');
-  };
-  return ws;
-}
+    setStatus('loading');
+    term.write('[connecting]\r\n');
+    const ws = new WebSocket(`ws://${location.host}/ws?token=${token}&sid=${sid}`);
+    ws.onopen = () => {
+      setStatus('open');
+      term.write('>> ');
+    };
+    ws.onmessage = ev => {
+      const lines = ev.data.split('\n');
+      let out = '';
+      for (const line of lines) {
+        if (line.startsWith('__PLOT__')) {
+          handlePlot(line.slice(8));
+        } else if (line.startsWith('__MODEL__')) {
+          handleModel(line.slice(9));
+        } else if (line) {
+          out += '\r\n' + line;
+        }
+      }
+      term.write(out + '\r\n>> ');
+    };
+    ws.onclose = () => {
+      setStatus('close');
+      term.write('\r\n[connection closed]\r\n');
+    };
+    ws.onerror = () => {
+      setStatus('error');
+      term.write('\r\n[connection error]\r\n');
+    };
+    return ws;
+  }
 function setActive(sid) {
   if (activeSid && sessions[activeSid]) {
     sessions[activeSid].tab.classList.remove('active');
@@ -191,16 +276,17 @@ function createSession(sid) {
   const el = document.createElement('div');
   el.className = 'frame hidden';
   container.appendChild(el);
-  const term = new Terminal({
-    cursorBlink: true,
-    theme: window.matchMedia('(prefers-color-scheme: dark)').matches ? {
-      background: '#1e1e1e',
-      foreground: '#d4d4d4'
-    } : {
-      background: '#ffffff',
-      foreground: '#000000'
-    }
-  });
+    const isDark = document.body.dataset.theme === 'dark';
+    const term = new Terminal({
+      cursorBlink: true,
+      theme: isDark ? {
+        background: '#1e1e1e',
+        foreground: '#d4d4d4'
+      } : {
+        background: '#ffffff',
+        foreground: '#000000'
+      }
+    });
   term.open(el);
   const ws = connect(sid, term);
   sessions[sid] = { term, ws, el, buffer: '' };


### PR DESCRIPTION
## Summary
- add dark/light theme toggle with CSS variables and Material icons
- load Google fonts and adapt layout for mobile
- show connection loading/error states

## Testing
- `./run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68941545724883298970a2990bf4664e