### PR TITLE
refine command descriptions and remove color toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,13 +130,12 @@ The terminal, invoked after login, serves as the shell for Arianna Core.
 	•	Logs: Each session logs to /arianna_core/log/, stamped with UTC.
 	•	max_log_files option in ~/.letsgo/config to limit disk usage.
 	•	History: /arianna_core/log/history persists command history, loaded at startup, updated on exit.
-	•	Tab completion (readline): suggests built-in verbs — /status, /time, /run, /summarize, /search, /color, /help.
+	•	Tab completion (readline): suggests built-in verbs — /status, /time, /run, /summarize, /search, /help.
 	•	/status: Reports CPU cores, uptime (from /proc/uptime), and current IP.
 	•	/summarize: Searches logs (with regex), prints last five matches; --history searches command history; /search <pattern> finds all matches.
 	•	/time: Prints current UTC.
 	•	/run : Executes shell command.
 	•	/help: Lists verbs.
-	•	/color on|off: Toggles colored output.
 	•	Unrecognized input: echoed back.
 	•	Structure ready for more advanced NLP (text hooks dispatch to remote models).
 

--- a/letsgo.py
+++ b/letsgo.py
@@ -423,8 +423,9 @@ async def handle_py(user: str) -> Tuple[str, str | None]:
 
 
 async def handle_clear(_: str) -> Tuple[str, str | None]:
-    os.system("clear")
-    return "", None
+    print(clear_screen(), end="")
+    reply = "Cleared."
+    return reply, reply
 
 
 async def handle_history(user: str) -> Tuple[str, str | None]:
@@ -478,39 +479,24 @@ async def handle_ping(_: str) -> Tuple[str, str | None]:
     return reply, reply
 
 
-async def handle_color(user: str) -> Tuple[str, str | None]:
-    parts = user.split()
-    if len(parts) != 2 or parts[1] not in {"on", "off"}:
-        reply = "Usage: /color on|off"
-        return reply, reply
-    global USE_COLOR
-    USE_COLOR = parts[1] == "on"
-    SETTINGS.use_color = USE_COLOR
-    _save_settings()
-    state = "enabled" if USE_COLOR else "disabled"
-    reply = f"color {state}"
-    return reply, color(reply, SETTINGS.green)
-
-
 CORE_COMMANDS: Dict[str, Tuple[Handler, str]] = {
-    "/status": (handle_status, "show basic system metrics"),
+    "/status": (handle_status, "show system metrics"),
     "/cpu": (handle_cpu, "show CPU load"),
-    "/disk": (handle_disk, "show disk usage"),
-    "/net": (handle_net, "show network parameters"),
-    "/time": (handle_time, "show current UTC time"),
-    "/run": (handle_run, "run a shell command"),
+    "/disk": (handle_disk, "disk usage"),
+    "/net": (handle_net, "network parameters"),
+    "/time": (handle_time, "curent UTC time"),
+    "/run": (handle_run, "shell command"),
     "/py": (handle_py, "execute Python code"),
-    "/summarize": (handle_summarize, "summarize log entries"),
-    "/clear": (handle_clear, "clear the terminal screen"),
-    "/history": (handle_history, "show command history"),
-    "/help": (handle_help, "show this help message"),
+    "/summarize": (handle_summarize, "log entries"),
+    "/clear": (handle_clear, "clear the terminal"),
+    "/history": (handle_history, "command history"),
+    "/help": (handle_help, "help message"),
     "/search": (handle_search, "search command history"),
     "/ping": (handle_ping, "reply with pong"),
-    "/color": (handle_color, "toggle colored output"),
 }
 
 COMMAND_HELP: Dict[str, str] = {
-    "/status": "Usage: /status\nShow basic system metrics.",
+    "/status": "Usage: /status\nShow system metrics.",
     "/cpu": "Usage: /cpu\nShow CPU load averages.",
     "/disk": "Usage: /disk\nShow disk usage information.",
     "/net": "Usage: /net\nShow network parameters.",
@@ -521,12 +507,11 @@ COMMAND_HELP: Dict[str, str] = {
         "Usage: /summarize [--history] [limit]"
         "\nSummarize recent log entries or command history."
     ),
-    "/clear": "Usage: /clear\nClear the terminal screen.",
+    "/clear": "Usage: /clear\nClear the terminal.",
     "/history": "Usage: /history [n]\nShow the last n commands.",
     "/help": "Usage: /help [command]\nList commands or show detailed help.",
     "/search": "Usage: /search <pattern>\nSearch the command history.",
     "/ping": "Usage: /ping\nReply with pong.",
-    "/color": "Usage: /color on|off\nEnable or disable colored output.",
 }
 
 COMMAND_HANDLERS: Dict[str, Handler] = {

--- a/tests/test_letsgo.py
+++ b/tests/test_letsgo.py
@@ -132,21 +132,19 @@ def test_search_history(tmp_path, monkeypatch):
     assert result.splitlines() == ["foo", "foobar"]
 
 
-def test_clear_command_registered(monkeypatch):
+def test_clear_command_registered(monkeypatch, capsys):
     commands = []
     handlers = {}
     letsgo.COMMAND_MAP.clear()
     letsgo.register_core(commands, handlers)
     assert "/clear" in commands
 
-    called = {"cmd": None}
-
-    def fake_system(cmd):
-        called["cmd"] = cmd
-
-    monkeypatch.setattr(os, "system", fake_system)
-    asyncio.run(handlers["/clear"]("/clear"))
-    assert called["cmd"] == "clear"
+    monkeypatch.setattr(letsgo, "clear_screen", lambda: "")
+    output, colored = asyncio.run(handlers["/clear"]("/clear"))
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert output == "Cleared."
+    assert colored == "Cleared."
 
 
 def test_help_lists_command_descriptions():
@@ -156,9 +154,9 @@ def test_help_lists_command_descriptions():
     letsgo.register_core(commands, handlers)
     output, _ = asyncio.run(letsgo.handle_help("/help"))
     assert "/clear" in output
-    assert "clear the terminal screen" in output
+    assert "clear the terminal" in output
     assert "/history" in output
-    assert "show command history" in output
+    assert "command history" in output
 
 
 def test_help_specific_command():
@@ -198,12 +196,3 @@ def test_handle_py_timeout(monkeypatch):
         assert colored.startswith("\033[31m")
     else:
         assert colored is not None
-
-
-def test_color_setting_persisted(tmp_path, monkeypatch):
-    config = tmp_path / "config"
-    monkeypatch.setattr(letsgo, "CONFIG_PATH", config)
-    monkeypatch.setattr(letsgo, "SETTINGS", letsgo.Settings())
-    monkeypatch.setattr(letsgo, "USE_COLOR", True)
-    asyncio.run(letsgo.handle_color("/color off"))
-    assert "use_color=False" in config.read_text()


### PR DESCRIPTION
## Summary
- streamline menu descriptions and drop `/color` command
- have `/clear` print a simple confirmation message
- update tests and docs for the new behavior

## Testing
- `./run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_689645bcddac8329a1082b2de788cfe0