### PR TITLE
Ensure /help always lists core commands

### DIFF
--- a/letsgo.py
+++ b/letsgo.py
@@ -439,17 +439,18 @@ async def handle_history(user: str) -> Tuple[str, str | None]:
 
 async def handle_help(user: str) -> Tuple[str, str | None]:
     parts = user.split(maxsplit=1)
+
+    lines = [f"{cmd} - {desc}" for cmd, (_, desc) in sorted(COMMAND_MAP.items())]
+    reply = "\n".join(lines)
+
     if len(parts) > 1:
         cmd = parts[1]
         help_text = COMMAND_HELP.get(cmd)
         if help_text:
-            return help_text, help_text
-        reply = f"No help available for {cmd}"
-        return reply, reply
-    lines: list[str] = []
-    for cmd, (_, desc) in sorted(COMMAND_MAP.items()):
-        lines.append(f"{cmd} - {desc}")
-    reply = "\n".join(lines)
+            reply = f"{reply}\n\n{help_text}"
+        else:
+            reply = f"{reply}\n\nNo help available for {cmd}"
+
     return reply, reply
 
 

--- a/tests/test_letsgo.py
+++ b/tests/test_letsgo.py
@@ -165,11 +165,17 @@ def test_help_specific_command():
     letsgo.COMMAND_MAP.clear()
     letsgo.register_core(commands, handlers)
     output, _ = asyncio.run(letsgo.handle_help("/help /time"))
+    assert "/clear - clear the terminal" in output
     assert "Usage: /time" in output
 
 
 def test_help_unknown_command():
+    commands = []
+    handlers = {}
+    letsgo.COMMAND_MAP.clear()
+    letsgo.register_core(commands, handlers)
     output, _ = asyncio.run(letsgo.handle_help("/help /missing"))
+    assert "/clear - clear the terminal" in output
     assert "No help available for /missing" in output
 
 


### PR DESCRIPTION
## Summary
- Always display core command list when invoking `/help`
- Extend help tests to assert command list is shown for specific and unknown commands

## Testing
- `./run-tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_689987b983e48329b116a66bd16edf8c