### PR TITLE
feat: auto format python and run commands

### DIFF
--- a/tests/test_letsgo.py
+++ b/tests/test_letsgo.py
@@ -202,3 +202,14 @@ def test_handle_py_timeout(monkeypatch):
         assert colored.startswith("\033[31m")
     else:
         assert colored is not None
+
+
+def test_run_python_dedents():
+    output, colored = asyncio.run(letsgo.run_python("    print('hi')"))
+    assert output == "hi"
+    assert colored == "hi"
+
+
+def test_looks_like_python_detection():
+    assert letsgo._looks_like_python("print('x')")
+    assert not letsgo._looks_like_python("echo hi")


### PR DESCRIPTION
## Summary
- auto-format Python code before execution
- fallback to shell or Python for plain messages
- cover new helpers with tests

## Testing
- `./run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68a8fc894a288329a5c46c6024b07b0c